### PR TITLE
Explicitly require python2

### DIFF
--- a/spoofcheck.py
+++ b/spoofcheck.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python2
 
 import sys
 


### PR DESCRIPTION
Until python3 is suported, explicitly specifiy use of legacy python2.

Many distros (Arch, Fedora, etc) use python3 as the default interpreter,
and thus unless python2 is explicitly stated, scripts will fail to
execute.